### PR TITLE
Port extension to use WebExtensions API when available

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+    "semi": true,
+    "tabWidth": 4
+}

--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
 # lodestone-inventory-grabber
-A chrome extension to grab retainer's inventory from lodestone
+
+A chrome / firefox extension to grab retainer's inventory from lodestone

--- a/manifest.json
+++ b/manifest.json
@@ -1,31 +1,27 @@
 {
-  "name": "Lodestone inventory grabber",
-  "version": "1.1.0",
-  "manifest_version": 2,
-  "description": "A chrome extension to grab retainer's inventory from lodestone into your clipboard",
-  "homepage_url": "https://ffxivteamcraft.com/recipe-finder",
-  "icons": {
-    "16": "icons/icon16.png",
-    "48": "icons/icon48.png",
-    "128": "icons/icon128.png"
-  },
-  "default_locale": "en",
-  "background": {
-    "scripts": [
-      "src/bg/background.js"
+    "name": "Lodestone inventory grabber",
+    "version": "1.2.0",
+    "manifest_version": 2,
+    "description": "A chrome extension to grab retainer's inventory from lodestone into your clipboard",
+    "homepage_url": "https://ffxivteamcraft.com/recipe-finder",
+    "icons": {
+        "16": "icons/icon16.png",
+        "48": "icons/icon48.png",
+        "128": "icons/icon128.png"
+    },
+    "default_locale": "en",
+    "background": {
+        "scripts": ["src/bg/background.js"],
+        "persistent": false
+    },
+    "browser_action": {
+        "default_icon": "icons/icon128.png",
+        "default_title": "Copy retainer's inventory inside clipboard"
+    },
+    "permissions": [
+        "activeTab",
+        "clipboardWrite",
+        "https://ffxivteamcraft.com/lodestone/character/*/retainer/*/baggage/"
     ],
-    "persistent": false
-  },
-  "browser_action": {
-    "default_icon": "icons/icon128.png",
-    "default_title": "Copy retainer's inventory inside clipboard"
-  },
-  "permissions": [
-    "activeTab",
-    "clipboardWrite",
-    "https://ffxivteamcraft.com/lodestone/character/*/retainer/*/baggage/"
-  ],
-  "web_accessible_resources": [
-    "data/items.json"
-  ]
+    "web_accessible_resources": ["data/items.json"]
 }

--- a/src/bg/background.js
+++ b/src/bg/background.js
@@ -1,4 +1,9 @@
-chrome.browserAction.onClicked.addListener(function(tab) {
-    chrome.tabs.executeScript(null, {file: "src/inject/inject.js"});
-});
+"use strict";
 
+void (() => {
+    const api = typeof browser === "object" ? browser : chrome;
+
+    api.browserAction.onClicked.addListener(() => {
+        api.tabs.executeScript(null, { file: "/src/inject/inject.js" });
+    });
+})();

--- a/src/inject/inject.js
+++ b/src/inject/inject.js
@@ -1,48 +1,77 @@
-function copyToClipboard(text) {
-    const input = document.createElement('input');
-    input.style.position = 'fixed';
-    input.style.opacity = 0;
-    input.value = text;
-    document.body.appendChild(input);
-    input.select();
-    document.execCommand('Copy');
-    document.body.removeChild(input);
-}
+"use strict";
 
-try {
-    const allItemNames = Array.from(document.getElementsByClassName('item-list__list sys_item_row'))
-        .map(el => {
-            return {
-                name: el.childNodes[3].childNodes[1].innerText,
-                amount: +el.dataset.stack,
-            }
-        });
+void (async () => {
+    const api = typeof browser === "object" ? browser : chrome;
 
-    let langFromUrl = /(fr|na|de|jp|eu).finalfantasyxiv.com/.exec(window.location.href)[1];
-
-    const lang = {
-        'fr': 'fr',
-        'na': 'en',
-        'eu': 'en',
-        'jp': 'ja',
-        'de': 'de'
-    }[langFromUrl];
-
-    fetch(chrome.runtime.getURL('data/items.json'))
-        .then((response) => response.json())
-        .then(items => {
-            const allIds = allItemNames.map(item => {
-                const id = Object.keys(items)
-                    .find(key => items[key][lang].trim().toLowerCase() === item.name.trim().toLowerCase());
+    try {
+        const allItemNames = Array.from(
+            document.getElementsByClassName("item-list__list sys_item_row"),
+            el => {
                 return {
-                    ...item,
-                    id: +id
+                    name: el.querySelector(".item-list__name--inline > a")
+                        .textContent,
+                    amount: parseInt(el.dataset.stack, 10)
                 };
-            });
-            copyToClipboard(JSON.stringify(allIds));
-            alert('Inventory copied inside your clipboard');
-        });
-} catch (_) {
-    alert('Please click this extension only when you\'re inside retainer\'s inventory page (https://finalfantasyxiv.com/lodestone/character/.../retainer/.../baggage)');
-}
+            }
+        );
 
+        const langFromUrl = /(fr|na|de|jp|eu).finalfantasyxiv.com/.exec(
+            location.href
+        )[1];
+
+        const lang = {
+            fr: "fr",
+            na: "en",
+            eu: "en",
+            jp: "ja",
+            de: "de"
+        }[langFromUrl];
+
+        const items = await (await fetch(
+            api.runtime.getURL("/data/items.json")
+        )).json();
+        const nameMap = new Map(
+            Object.entries(items).map(([id, { [lang]: name }]) => [name, id])
+        );
+        const nameList = Array.from(nameMap.keys());
+        const allIds = allItemNames.map(item => {
+            const id = nameMap.get(
+                nameList.find(
+                    name => name.trim().localeCompare(item.name.trim()) === 0
+                )
+            );
+            return {
+                ...item,
+                id: id !== undefined ? parseInt(id, 10) : -1
+            };
+        });
+        await copyToClipboard(JSON.stringify(allIds));
+
+        alert("Inventory copied inside your clipboard");
+    } catch (_) {
+        // it is possible to enable/disable the button
+        // depending on the current page's url, but that
+        // requires "tabs" instead of just "activeTab" privileges
+        alert(
+            "Please click this extension only when you're inside retainer's inventory page (https://finalfantasyxiv.com/lodestone/character/.../retainer/.../baggage)"
+        );
+    }
+
+    async function copyToClipboard(text) {
+        if (
+            typeof navigator.clipboard === "object" &&
+            navigator.clipboard.writeText
+        ) {
+            return navigator.clipboard.writeText(text);
+        }
+
+        const input = document.createElement("input");
+        input.style.position = "fixed";
+        input.style.opacity = 0;
+        input.value = text;
+        document.body.appendChild(input);
+        input.select();
+        document.execCommand("copy");
+        document.body.removeChild(input);
+    }
+})();

--- a/src/inject/inject.js
+++ b/src/inject/inject.js
@@ -31,13 +31,17 @@ void (async () => {
             api.runtime.getURL("/data/items.json")
         )).json();
         const nameMap = new Map(
-            Object.entries(items).map(([id, { [lang]: name }]) => [name, id])
+            Object.entries(items).map(([id, { [lang]: name }]) => [
+                name.trim(),
+                id
+            ])
         );
         const nameList = Array.from(nameMap.keys());
+        const collator = new Intl.Collator(lang, { usage: "search" });
         const allIds = allItemNames.map(item => {
             const id = nameMap.get(
                 nameList.find(
-                    name => name.trim().localeCompare(item.name.trim()) === 0
+                    name => collator.compare(name, item.name.trim()) === 0
                 )
             );
             return {

--- a/src/inject/inject.js
+++ b/src/inject/inject.js
@@ -37,7 +37,10 @@ void (async () => {
             ])
         );
         const nameList = Array.from(nameMap.keys());
-        const collator = new Intl.Collator(lang, { usage: "search" });
+        const collator = new Intl.Collator(lang, {
+            usage: "search",
+            sensitivity: "base"
+        });
         const allIds = allItemNames.map(item => {
             const id = nameMap.get(
                 nameList.find(


### PR DESCRIPTION
While the extension did happen to work as-is on Firefox thanks to their
compatibility API, it wasn't much work to just make it use the
WebExtensions API as nearly nothing changes.

This also refactors the code to be strict mode, avoid leaking variables
to global scope, and to use the native clipboard API, if available,
instead of manipulating the page's text selection. The item id mapping
loop was optimized as well.

The extension pretty much just needs to be [packaged](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Getting_started_with_web-ext#Packaging_your_extension) and [put on AMO](https://addons.mozilla.org/en-US/developers/addon/submit/).